### PR TITLE
ensure index is up to date for prompt_git()

### DIFF
--- a/bash/bash_prompt
+++ b/bash/bash_prompt
@@ -78,6 +78,9 @@ prompt_git() {
         return 1
     fi
 
+    # ensure index is up to date
+    git update-index --really-refresh  -q &>/dev/null
+    
     git_info=$(get_git_branch)
 
     # Check for uncommitted changes in the index


### PR DESCRIPTION
Note: git will ignore empty dirs unless they contain a .gitignore
file. The prompt should be correct with the caveat that it ignores any
new empty folders.

Ref: https://github.com/necolas/dotfiles/issues/17
