### PR TITLE
Fix Non-Printing Characters Escaped Twice

### DIFF
--- a/shell/bash_prompt
+++ b/shell/bash_prompt
@@ -113,16 +113,16 @@ set_prompts() {
 
     # logged in as root
     if [[ "$USER" == "root" ]]; then
-        userStyle="\[$bold$red\]"
+        userStyle="$bold$red"
     else
-        userStyle="\[$orange\]"
+        userStyle="$orange"
     fi
 
     # connected via ssh
     if [[ "$SSH_TTY" ]]; then
-        hostStyle="\[$bold$red\]"
+        hostStyle="$bold$red"
     else
-        hostStyle="\[$yellow\]"
+        hostStyle="$yellow"
     fi
 
     # set the terminal title to the current working directory


### PR DESCRIPTION
`\[` and `\]` means:

> everything between these escaped square brackets, including the brackets themselves, is a non-printing character.

Line 132 and line 134 where `userStyle` and `hostStyle` are used respectively already have the square bracket escapes, but the definitions also contain square brackets. They are escaped twice. I believe this is incorrect. I see weird characters in the bash prompt before this change, and they disappear after this change.

Screenshot available upon request, thanks.
