### PR TITLE
Set prompt_git colors as non-printing characters

### DIFF
--- a/shell/bash_prompt
+++ b/shell/bash_prompt
@@ -134,7 +134,7 @@ set_prompts() {
     PS1+="\[$hostStyle\]\h" # host
     PS1+="\[$reset$white\]: "
     PS1+="\[$green\]\w" # working directory
-    PS1+="\$(prompt_git \"$white on $cyan\")" # git repository details
+    PS1+="\$(prompt_git \"\[$white\] on \[$cyan\]\")" # git repository details
     PS1+="\n"
     PS1+="\[$reset$white\]\$ \[$reset\]" # $ (and reset color)
 


### PR DESCRIPTION
My editor was wrapping lines incorrectly before this change. Hope this helps!